### PR TITLE
Python poc: expanded coverage of compliance tests

### DIFF
--- a/openeo_compliance_tests/openeo_compliance_tests/conftest.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/conftest.py
@@ -1,11 +1,10 @@
 """
 Reusable test fixtures
 """
-import re
 
 import pytest
 
-from openeo_compliance_tests.helpers import ApiClient, ApiSchemaValidator
+from openeo_compliance_tests.helpers import ApiClient, ApiSchemaValidator, get_api_version
 
 
 @pytest.fixture
@@ -16,18 +15,7 @@ def client(request):
 
 @pytest.fixture
 def api_version(request):
-    version = request.config.getoption('--api-version')
-    if version:
-        if not re.match(r'^\d+\.\d+\.\d+$', version):
-            raise Exception('Invalid API version: {v!r}'.format(v=version))
-    else:
-        # Try to guess from backend url
-        backend = request.config.getoption("--backend")
-        match = re.search(r'(\d+)[._-](\d+)[._-](\d+)', backend)
-        if not match:
-            raise Exception('Failed to guess API version from backend url {b}.'.format(b=backend))
-        version = '.'.join(match.groups())
-    return version
+    return get_api_version(request.config)
 
 
 @pytest.fixture

--- a/openeo_compliance_tests/openeo_compliance_tests/helpers.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/helpers.py
@@ -1,6 +1,7 @@
 import json
 import pkgutil
 import re
+from urllib.parse import urlparse
 
 import _pytest.config
 import jsonschema
@@ -14,6 +15,11 @@ class ApiClient:
     def __init__(self, backend: str):
         self.s = Session()
         self.backend = backend.rstrip('/')
+
+    @property
+    def domain(self):
+        parsed = urlparse(self.backend)
+        return '{s}://{d}'.format(s=parsed.scheme, d=parsed.netloc)
 
     def get(self, path: str) -> Response:
         assert path.startswith('/')

--- a/openeo_compliance_tests/openeo_compliance_tests/helpers.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/helpers.py
@@ -9,11 +9,12 @@ class ApiClient:
     """Simple `requests` based API client."""
     _timeout = 1
 
-    def __init__(self, backend):
+    def __init__(self, backend: str):
         self.s = Session()
-        self.backend = backend
+        self.backend = backend.rstrip('/')
 
-    def get_json(self, path) -> dict:
+    def get_json(self, path: str) -> dict:
+        assert path.startswith('/')
         r = self.s.get(self.backend + path, timeout=self._timeout)
         r.raise_for_status()
         return r.json()

--- a/openeo_compliance_tests/openeo_compliance_tests/helpers.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/helpers.py
@@ -20,6 +20,8 @@ class ApiClient:
         return r.json()
 
 
+class ResponseNotInSchema(KeyError): pass
+
 class ApiSchemaValidator:
     """
     Helper class to load an OpenEo API schema definition
@@ -50,7 +52,10 @@ class ApiSchemaValidator:
     def get_response_validator(self, path: str = '/', operation: str = 'get', code: str = '200',
                                media_type: str = 'application/json', ) -> jsonschema.Draft4Validator:
         """Helper to get the response schema of a given request path"""
-        schema = self._schema['paths'][path][operation]['responses'][code]['content'][media_type]['schema']
+        try:
+            schema = self._schema['paths'][path][operation]['responses'][code]['content'][media_type]['schema']
+        except KeyError as e:
+            raise ResponseNotInSchema(*e.args) from None
         return self._get_validator(schema)
 
     def get_paths(self):

--- a/openeo_compliance_tests/openeo_compliance_tests/helpers.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/helpers.py
@@ -21,12 +21,16 @@ class ApiClient:
         parsed = urlparse(self.backend)
         return '{s}://{d}'.format(s=parsed.scheme, d=parsed.netloc)
 
-    def get(self, path: str) -> Response:
+    def request(self, method: str, path: str, **kwargs):
         assert path.startswith('/')
-        return self.s.get(self.backend + path, timeout=self._timeout)
+        timeout = kwargs.pop('timeout', self._timeout)
+        return self.s.request(method=method, url=self.backend + path, timeout=timeout, **kwargs)
 
-    def get_json(self, path: str) -> dict:
-        r = self.get(path)
+    def get(self, path: str, **kwargs) -> Response:
+        return self.request(method='get', path=path, **kwargs)
+
+    def get_json(self, path: str, **kwargs) -> dict:
+        r = self.get(path, **kwargs)
         r.raise_for_status()
         return r.json()
 

--- a/openeo_compliance_tests/openeo_compliance_tests/test_cors.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/test_cors.py
@@ -1,0 +1,42 @@
+"""
+
+Tests for handling of Cross-Origin Resource Sharing (CORS)
+https://open-eo.github.io/openeo-api/cors/
+
+"""
+import pytest
+import requests
+
+from openeo_compliance_tests.helpers import ApiClient
+
+
+def csv_to_list(s: str):
+    """Parse comma-separated list (and make lowercase)"""
+    return [x.lower().strip() for x in s.split(',')]
+
+
+@pytest.mark.parametrize("path", [
+    '/',
+    '/collections',
+    # TODO: more endpoints?
+])
+def test_options_request(client: ApiClient, path: str):
+    origin = 'http://example.com'
+    r = client.request(method='options', path=path, headers={'Origin': origin})
+
+    assert r.status_code == requests.codes.no_content  # 204
+
+    # Note: r.headers is CaseInsensitiveDict
+    assert r.headers['access-control-allow-origin'] == origin
+
+    # TODO test Access-Control-Allow-Credentials (depends on whether backend supports authentication)
+
+    assert 'content-type' in csv_to_list(r.headers['access-control-allow-headers'])
+
+    # TODO: check more methods?
+    assert 'get' in csv_to_list(r.headers['access-control-allow-methods'])
+
+    expose_headers = set(csv_to_list(r.headers['access-control-expose-headers']))
+    assert {'location', 'openeo-identifier', 'openeo-costs'}.issubset(expose_headers)
+
+    assert r.headers['content-type'] == 'application/json'

--- a/openeo_compliance_tests/openeo_compliance_tests/test_error_handling.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/test_error_handling.py
@@ -1,0 +1,54 @@
+"""
+
+https://open-eo.github.io/openeo-api/errors/
+
+"""
+
+import _pytest.python
+import pytest
+import requests
+
+from openeo_compliance_tests.helpers import ApiSchemaValidator, ApiClient, get_api_version
+
+
+def pytest_generate_tests(metafunc: _pytest.python.Metafunc):
+    """
+    Pytest hook for custom test parametrization
+    """
+    if 'unauthorized_get_path' in metafunc.fixturenames:
+        schema = ApiSchemaValidator.from_version(get_api_version(metafunc.config))
+        # Search for get requests which require authentication
+        paths = []
+        for path in schema.get_paths():
+            if '{' not in path:
+                path_get_schema = schema.get_path_schema(path).get('get', {})
+                if 'security' in path_get_schema and all(s != {} for s in path_get_schema['security']):
+                    paths.append(path)
+        metafunc.parametrize('unauthorized_get_path', paths)
+
+
+def test_get_unauthorized(client: ApiClient, unauthorized_get_path: str):
+    """
+    Check that paths that require authentication indeed return with a 401 Unauthorized HTTP code
+
+    https://open-eo.github.io/openeo-api/errors/#account_management
+    """
+    response = client.get(unauthorized_get_path)
+    if response.status_code == requests.codes.not_found:
+        pytest.skip('{p} not found'.format(p=unauthorized_get_path))
+    assert response.status_code == requests.codes.unauthorized
+
+
+@pytest.mark.parametrize(['path', 'http_code', 'error_code'], [
+    ('/invalid/path/to/nowhere', requests.codes.not_found, 'NotFound'),
+    ('/collections/invalid-collection-name-foobar', requests.codes.not_found, 'CollectionNotFound'),
+])
+def test_invalid_path(client: ApiClient, path: str, http_code: int, error_code:str):
+    """Test GET request to invalid path"""
+    r = client.get(path=path)
+    assert r.status_code == http_code
+    error = r.json()
+    assert isinstance(error, dict)
+    assert 'code' in error
+    assert error['code']  == error_code
+    assert 'message' in error

--- a/openeo_compliance_tests/openeo_compliance_tests/test_general.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/test_general.py
@@ -9,6 +9,7 @@ from openeo_compliance_tests.helpers import ApiSchemaValidator, ApiClient
     '/processes',
     '/output_formats',
     '/udf_runtimes',
+    '/service_types',
 ])
 def test_generic_get(client: ApiClient, schema: ApiSchemaValidator, path: str):
     """Generic validation of simple get requests"""

--- a/openeo_compliance_tests/openeo_compliance_tests/test_general.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/test_general.py
@@ -1,8 +1,6 @@
-import _pytest.python
 import pytest
-import requests
 
-from openeo_compliance_tests.helpers import ApiSchemaValidator, ApiClient, ResponseNotInSchema, get_api_version
+from openeo_compliance_tests.helpers import ApiSchemaValidator, ApiClient, ResponseNotInSchema
 
 
 @pytest.mark.parametrize("path", [
@@ -51,32 +49,3 @@ def test_well_known_openeo(client, schema, api_version):
     client = ApiClient(backend=client.domain)
     test_get_generic(client=client, schema=schema, api_version=api_version, path=path)
 
-
-def test_get_unauthorized(client: ApiClient, unauthorized_get_path: str):
-    """
-    Check that paths that require authentication indeed return with a 4XX HTTP code
-    """
-    response = client.get(unauthorized_get_path)
-    if response.status_code == requests.codes.not_found:
-        pytest.skip('{p} not found'.format(p=unauthorized_get_path))
-    assert response.status_code in (
-        requests.codes.unauthorized,  # HTTP status code 401
-        requests.codes.forbidden,  # HTTP status code 403
-        requests.codes.not_allowed,  # HTTP status code 405
-    )
-
-
-def pytest_generate_tests(metafunc: _pytest.python.Metafunc):
-    """
-    Pytest hook for custom test parametrization
-    """
-    if 'unauthorized_get_path' in metafunc.fixturenames:
-        schema = ApiSchemaValidator.from_version(get_api_version(metafunc.config))
-        # Search for get requests which require authentication
-        paths = []
-        for path in schema.get_paths():
-            if '{' not in path:
-                path_get_schema = schema.get_path_schema(path).get('get', {})
-                if 'security' in path_get_schema and all(s != {} for s in path_get_schema['security']):
-                    paths.append(path)
-        metafunc.parametrize('unauthorized_get_path', paths)

--- a/openeo_compliance_tests/openeo_compliance_tests/test_general.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/test_general.py
@@ -1,6 +1,8 @@
+import _pytest.python
 import pytest
+import requests
 
-from openeo_compliance_tests.helpers import ApiSchemaValidator, ApiClient, ResponseNotInSchema
+from openeo_compliance_tests.helpers import ApiSchemaValidator, ApiClient, ResponseNotInSchema, get_api_version
 
 
 @pytest.mark.parametrize("path", [
@@ -11,8 +13,10 @@ from openeo_compliance_tests.helpers import ApiSchemaValidator, ApiClient, Respo
     '/udf_runtimes',
     '/service_types',
 ])
-def test_generic_get(client: ApiClient, schema: ApiSchemaValidator, api_version: str, path: str):
-    """Generic validation of simple get requests"""
+def test_get_generic(client: ApiClient, schema: ApiSchemaValidator, api_version: str, path: str):
+    """
+    Generic validation of simple get requests
+    """
     response = client.get_json(path=path)
     try:
         validator = schema.get_response_validator(path=path)
@@ -38,3 +42,33 @@ def test_collections_collection_id(client, schema):
     for collection in client.get_json('/collections')['collections']:
         response = client.get_json('/collections/{cid}'.format(cid=collection[field]))
         validator.validate(response)
+
+
+def test_get_unauthorized(client: ApiClient, unauthorized_get_path: str):
+    """
+    Check that paths that require authentication indeed return with a 4XX HTTP code
+    """
+    response = client.get(unauthorized_get_path)
+    if response.status_code == requests.codes.not_found:
+        pytest.skip('{p} not found'.format(p=unauthorized_get_path))
+    assert response.status_code in (
+        requests.codes.unauthorized,  # HTTP status code 401
+        requests.codes.forbidden,  # HTTP status code 403
+        requests.codes.not_allowed,  # HTTP status code 405
+    )
+
+
+def pytest_generate_tests(metafunc: _pytest.python.Metafunc):
+    """
+    Pytest hook for custom test parametrization
+    """
+    if 'unauthorized_get_path' in metafunc.fixturenames:
+        schema = ApiSchemaValidator.from_version(get_api_version(metafunc.config))
+        # Search for get requests which require authentication
+        paths = []
+        for path in schema.get_paths():
+            if '{' not in path:
+                path_get_schema = schema.get_path_schema(path).get('get', {})
+                if 'security' in path_get_schema and all(s != {} for s in path_get_schema['security']):
+                    paths.append(path)
+        metafunc.parametrize('unauthorized_get_path', paths)

--- a/openeo_compliance_tests/openeo_compliance_tests/test_general.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/test_general.py
@@ -1,6 +1,6 @@
 import pytest
 
-from openeo_compliance_tests.helpers import ApiSchemaValidator, ApiClient
+from openeo_compliance_tests.helpers import ApiSchemaValidator, ApiClient, ResponseNotInSchema
 
 
 @pytest.mark.parametrize("path", [
@@ -11,10 +11,15 @@ from openeo_compliance_tests.helpers import ApiSchemaValidator, ApiClient
     '/udf_runtimes',
     '/service_types',
 ])
-def test_generic_get(client: ApiClient, schema: ApiSchemaValidator, path: str):
+def test_generic_get(client: ApiClient, schema: ApiSchemaValidator, api_version: str, path: str):
     """Generic validation of simple get requests"""
     response = client.get_json(path=path)
-    schema.get_response_validator(path=path).validate(response)
+    try:
+        validator = schema.get_response_validator(path=path)
+    except ResponseNotInSchema:
+        # Automatically skip paths that are not in tested API version (e.g. when validating against older schemas)
+        pytest.skip('Path {p!r} not in schema version {v}'.format(p=path, v=api_version))
+    validator.validate(response)
 
 
 def test_collections_collection_id(client, schema):

--- a/openeo_compliance_tests/openeo_compliance_tests/test_general.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/test_general.py
@@ -1,14 +1,22 @@
-def test_capabilities(client, schema):
-    response = client.get_json("/")
-    schema.get_response_validator(path='/').validate(response)
+import pytest
+
+from openeo_compliance_tests.helpers import ApiSchemaValidator, ApiClient
 
 
-def test_collections(client, schema):
-    response = client.get_json("/collections")
-    schema.get_response_validator(path='/collections').validate(response)
+@pytest.mark.parametrize("path", [
+    '/',
+    '/collections',
+    '/processes',
+    '/output_formats',
+    '/udf_runtimes',
+])
+def test_generic_get(client: ApiClient, schema: ApiSchemaValidator, path: str):
+    """Generic validation of simple get requests"""
+    response = client.get_json(path=path)
+    schema.get_response_validator(path=path).validate(response)
 
 
-def test_collections_collection_id(client, schema, api_version):
+def test_collections_collection_id(client, schema):
     if '/collections/{collection_id}' in schema.get_paths():
         # Since 0.4.0
         path = '/collections/{collection_id}'
@@ -19,22 +27,8 @@ def test_collections_collection_id(client, schema, api_version):
         field = 'name'
     validator = schema.get_response_validator(path=path)
 
-    # TODO: handle this loop with pytest.mark.parametrize
+    # TODO: handle this loop with pytest.mark.parametrize?
+    # TODO: limit the number of collections to check?
     for collection in client.get_json('/collections')['collections']:
         response = client.get_json('/collections/{cid}'.format(cid=collection[field]))
         validator.validate(response)
-
-
-def test_processes(client, schema):
-    response = client.get_json('/processes')
-    schema.get_response_validator(path='/processes').validate(response)
-
-
-def test_output_formats(client, schema):
-    response = client.get_json('/output_formats')
-    schema.get_response_validator(path='/output_formats').validate(response)
-
-
-def test_udf_runtimes(client, schema):
-    response = client.get_json('/udf_runtimes')
-    schema.get_response_validator(path='/udf_runtimes').validate(response)

--- a/openeo_compliance_tests/openeo_compliance_tests/test_general.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/test_general.py
@@ -28,3 +28,13 @@ def test_collections_collection_id(client, schema, api_version):
 def test_processes(client, schema):
     response = client.get_json('/processes')
     schema.get_response_validator(path='/processes').validate(response)
+
+
+def test_output_formats(client, schema):
+    response = client.get_json('/output_formats')
+    schema.get_response_validator(path='/output_formats').validate(response)
+
+
+def test_udf_runtimes(client, schema):
+    response = client.get_json('/udf_runtimes')
+    schema.get_response_validator(path='/udf_runtimes').validate(response)


### PR DESCRIPTION
- expand coverage of basic GET requests (e.g. `/output_formats`, `/udf_runtimes`, `/service_types`)
- when testing older API version: automatically skip validation of requests that are not in spec
- test if requests that require validation return with appropriate error
- add test for /.well-known/openeo (special case becuase has to be at domain root)
- add initial/poc tests about error handling (collection not found, path not found)