### PR TITLE
Issue #15: pytest suite: refactor validation to allow swapping validation tool

### DIFF
--- a/openeo_compliance_tests/openeo_compliance_tests/conftest.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/conftest.py
@@ -4,7 +4,7 @@ Reusable test fixtures
 
 import pytest
 
-from openeo_compliance_tests.helpers import ApiClient, ApiSchemaValidator, get_api_version
+from openeo_compliance_tests.helpers import ApiClient, get_api_version, OpenApiSpec, PurePythonValidator
 
 
 @pytest.fixture
@@ -19,6 +19,10 @@ def api_version(request):
 
 
 @pytest.fixture
-def schema(api_version) -> ApiSchemaValidator:
-    """Pytest fixture for expected API schema for desired version"""
-    return ApiSchemaValidator.from_version(api_version)
+def spec(api_version: str):
+    return OpenApiSpec.from_version(api_version)
+
+
+@pytest.fixture
+def validator(spec: OpenApiSpec):
+    return PurePythonValidator(spec)

--- a/openeo_compliance_tests/openeo_compliance_tests/test_general.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/test_general.py
@@ -1,6 +1,6 @@
 import pytest
 
-from openeo_compliance_tests.helpers import ApiSchemaValidator, ApiClient, ResponseNotInSchema
+from openeo_compliance_tests.helpers import ApiClient, ResponseNotInSchema, OpenApiValidator, OpenApiSpec
 
 
 @pytest.mark.parametrize("path", [
@@ -11,22 +11,20 @@ from openeo_compliance_tests.helpers import ApiSchemaValidator, ApiClient, Respo
     '/udf_runtimes',
     '/service_types',
 ])
-def test_get_generic(client: ApiClient, schema: ApiSchemaValidator, api_version: str, path: str):
+def test_get_generic(client: ApiClient, validator: OpenApiValidator, api_version: str, path: str):
     """
     Generic validation of simple get requests
     """
     try:
-        validator = schema.get_response_validator(path=path)
+        response = client.get(path=path)
+        validator.validate_response(path=path, response=response, method='get')
     except ResponseNotInSchema:
         # Automatically skip paths that are not in tested API version (e.g. when validating against older schemas)
         pytest.skip('Path {p!r} not in schema version {v}'.format(p=path, v=api_version))
-    else:
-        response = client.get_json(path=path)
-        validator.validate(response)
 
 
-def test_collections_collection_id(client, schema):
-    if '/collections/{collection_id}' in schema.get_paths():
+def test_collections_collection_id(client: ApiClient, spec: OpenApiSpec, validator: OpenApiValidator):
+    if '/collections/{collection_id}' in spec.get_paths():
         # Since 0.4.0
         path = '/collections/{collection_id}'
         field = 'id'
@@ -34,18 +32,16 @@ def test_collections_collection_id(client, schema):
         # Old pre-0.4.0 style
         path = '/collections/{name}'
         field = 'name'
-    validator = schema.get_response_validator(path=path)
 
     # TODO: handle this loop with pytest.mark.parametrize?
-    # TODO: limit the number of collections to check?
-    for collection in client.get_json('/collections')['collections']:
-        response = client.get_json('/collections/{cid}'.format(cid=collection[field]))
-        validator.validate(response)
+    # TODO: option to limit the number of collections to check?
+    for collection in client.get('/collections').json()['collections'][:10]:
+        response = client.get('/collections/{cid}'.format(cid=collection[field]))
+        validator.validate_response(path=path, response=response, method='get')
 
 
-def test_well_known_openeo(client, schema, api_version):
+def test_well_known_openeo(client, validator, api_version):
     # Special case: /.well-known/openeo should be available directly under domain
     path = '/.well-known/openeo'
     client = ApiClient(backend=client.domain)
-    test_get_generic(client=client, schema=schema, api_version=api_version, path=path)
-
+    test_get_generic(client=client, validator=validator, api_version=api_version, path=path)

--- a/openeo_compliance_tests/openeo_compliance_tests/test_helpers.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/test_helpers.py
@@ -1,56 +1,163 @@
+import contextlib
+import json
+import pathlib
+from typing import Union
+
 import jsonschema
 import pytest
+from requests import Response
 
-from openeo_compliance_tests.helpers import ApiSchemaValidator
+from openeo_compliance_tests.helpers import OpenApiSpec, PurePythonValidator, ResponseNotInSchema
 
-SIMPLE_SCHEMA = {
+TEST_SCHEMA = {
     "openapi": "3.0.2",
     "info": {
         "title": "Simple API",
         "version": "1.2.3"
     },
     "paths": {
-        "/helloworld": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Computer says hello world",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "greeting",
-                                    ],
-                                    "properties": {
-                                        "greeting": {
-                                            "type": "string",
-                                        },
-                                        "subject": {
-                                            "type": "string",
-                                        }
-                                    }
-                                }
-                            }
-                        }
+        "/helloworld": {"get": {"responses": {"200": {
+            "description": "Computer says hello world",
+            "content": {"application/json": {
+                "schema": {
+                    "type": "object",
+                    "required": ["greeting"],
+                    "properties": {
+                        "greeting": {"type": "string"},
+                        "subject": {"type": "string"}
                     }
                 }
+            }}
+        }}}},
+        "/with_ref": {"get": {"responses": {"200": {
+            "description": "schema with refs",
+            "content": {"application/json": {
+                "schema": {
+                    "type": "array",
+                    "items": {"$ref": "#/components/schemas/reffed"}
+
+                }
+            }}
+        }}}},
+        "/with_nullable": {"get": {"responses": {"200": {
+            "description": "schema with nullable values",
+            "content": {"application/json": {
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "nullable": True
+                    }
+                }
+            }}
+        }}}}
+    },
+    "components": {
+        "schemas": {
+            "reffed": {
+                "type": "object",
+                "required": ["bar"],
+                "properties": {
+                    "bar": {"$ref": "#/components/schemas/bar"},
+                    "foo": {"type": "integer"},
+                    "baz": {"$ref": "#/components/schemas/nullabar"}
+                }
+            },
+            "bar": {
+                "type": "string"
+            },
+            "nullabar": {
+                "type": "integer",
+                "nullable": True
             }
         }
     }
 }
 
 
-def test_api_schema_validator():
-    schema = ApiSchemaValidator(SIMPLE_SCHEMA)
-    validator = schema.get_response_validator(path='/helloworld')
-    validator.validate({'greeting': 'hello', 'subject': 'world'})
-    validator.validate({'greeting': 'hello'})
-    with pytest.raises(jsonschema.ValidationError, match="'greeting' is a required property"):
-        validator.validate({})
+def test_openapi_spec_dict():
+    spec = OpenApiSpec(TEST_SCHEMA)
+    assert '/helloworld' in spec.get_paths()
+    with pytest.raises(RuntimeError, match='Real path is not known'):
+        p = spec.path
+    assert spec.get_path_schema('/helloworld')['get']['responses']['200']['description'] == 'Computer says hello world'
 
 
-def test_api_schema_validator_wrong_path():
-    schema = ApiSchemaValidator(SIMPLE_SCHEMA)
-    with pytest.raises(KeyError):
-        schema.get_response_validator(path='/foobar')
+def test_openapi_spec_from_version():
+    spec = OpenApiSpec.from_version('0.4.0')
+    assert '/' in spec.get_paths()
+    assert isinstance(spec.path, pathlib.Path)
+    assert spec.path.name == 'openeo-api-0.4.0.json'
+
+
+def resp(body: Union[str, dict] = '', status: int = 200):
+    """Factory for dummy responses"""
+    r = Response()
+    if isinstance(body, dict):
+        body = json.dumps(body)
+    r._content = body.encode('utf-8')
+    r.status_code = status
+    return r
+
+
+@contextlib.contextmanager
+def nullcontext():
+    yield
+
+
+class TestPurePythonValidator:
+
+    def test_validator(self):
+        validator = PurePythonValidator(spec=OpenApiSpec(TEST_SCHEMA))
+        validator.validate_response(path='/helloworld', response=resp(body='{"greeting": "hello", "subject": "world"}'))
+        validator.validate_response(path='/helloworld', response=resp(body='{"greeting": "hello"}'))
+        with pytest.raises(jsonschema.ValidationError, match="'greeting' is a required property"):
+            validator.validate_response(path='/helloworld', response=resp(body='{}'))
+
+    def test_wrong_path(self):
+        validator = PurePythonValidator(spec=OpenApiSpec(TEST_SCHEMA))
+        with pytest.raises(ResponseNotInSchema):
+            validator.validate_response(path='/foobar', response=resp(body='{"greeting": "hello"}'))
+
+    @pytest.mark.parametrize(["valid", "body"], [
+        (True, '[]'),
+        (False, '[{}]'),
+        (False, '[{"foo": 123}]'),
+        (False, '[{"bar": 123}]'),
+        (True, '[{"bar": "one"}]'),
+        (True, '[{"bar": "one"}, {"bar": "two"}]'),
+        (False, '[{"bar": "one"}, {"bar": 123}]'),
+        (False, '[{"bar": "one", "foo": "two"}]'),
+        (True, '[{"bar": "one", "foo": 123}]'),
+    ])
+    def test_ref_resolving(self, valid, body):
+        validator = PurePythonValidator(spec=OpenApiSpec(TEST_SCHEMA))
+        expectation = nullcontext() if valid else pytest.raises(jsonschema.ValidationError)
+        with expectation:
+            validator.validate_response(path='/with_ref', method='get', response=resp(body=body))
+
+    @pytest.mark.parametrize(["valid", "body"], [
+        (True, '[]'),
+        (True, '["foo"]'),
+        (True, '["foo", "bar"]'),
+        (False, '["foo", 123]'),
+        (False, '["foo", {"ba": "r"}]'),
+        (True, '["foo", null]'),
+    ])
+    def test_nullable(self, valid, body):
+        validator = PurePythonValidator(spec=OpenApiSpec(TEST_SCHEMA))
+        expectation = nullcontext() if valid else pytest.raises(jsonschema.ValidationError)
+        with expectation:
+            validator.validate_response(path='/with_nullable', method='get', response=resp(body=body))
+
+    @pytest.mark.parametrize(["valid", "body"], [
+        (True, '[{"bar": "one"}]'),
+        (False, '[{"bar": "one", "baz": "two"}]'),
+        (True, '[{"bar": "one", "baz": 123}]'),
+        (True, '[{"bar": "one", "baz": null}]'),
+    ])
+    def test_nullable_ref(self, valid, body):
+        validator = PurePythonValidator(spec=OpenApiSpec(TEST_SCHEMA))
+        expectation = nullcontext() if valid else pytest.raises(jsonschema.ValidationError)
+        with expectation:
+            validator.validate_response(path='/with_ref', method='get', response=resp(body=body))

--- a/openeo_compliance_tests/requirements.txt
+++ b/openeo_compliance_tests/requirements.txt
@@ -2,3 +2,4 @@ requests
 pytest
 attrs>=17.4.0
 jsonschema
+openapi_schema_to_json_schema


### PR DESCRIPTION
This addresses issue #15 as discussed with @bgoesswe 

This refactor makes it possible to replace the current pure python based OpenApi validation with another approach (e.g. through the Go tool or a node.js based validator)

Current pure python validator combines [jsonschema validator](https://github.com/Julian/jsonschema) with [openapi_schema_to_json_schema](https://github.com/pglass/py-openapi-schema-to-json-schema) to handle the differences between JSONschema and OpenAPI, for example to handle `nullable` correctly.