### PR TITLE
Issue #28: skip endpoints that are not listed in backend's capabilities

### DIFF
--- a/openeo_compliance_tests/openeo_compliance_tests/helpers.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/helpers.py
@@ -172,3 +172,16 @@ class GoToolValidator(OpenApiValidator):
         status_code = response.status_code
         headers = response.headers
         body = response.text
+
+
+class Capabilities:
+    """Helper to query the capabilities of a backend."""
+
+    def __init__(self, capabilities: dict):
+        self.capabilities = capabilities
+
+    def has_endpoint(self, endpoint, method='get'):
+        return any(
+            e['path'] == endpoint and method.lower() in set(m.lower() for m in e['methods'])
+            for e in self.capabilities['endpoints']
+        )

--- a/openeo_compliance_tests/openeo_compliance_tests/test_helpers.py
+++ b/openeo_compliance_tests/openeo_compliance_tests/test_helpers.py
@@ -7,7 +7,7 @@ import jsonschema
 import pytest
 from requests import Response
 
-from openeo_compliance_tests.helpers import OpenApiSpec, PurePythonValidator, ResponseNotInSchema
+from openeo_compliance_tests.helpers import OpenApiSpec, PurePythonValidator, ResponseNotInSchema, Capabilities
 
 TEST_SCHEMA = {
     "openapi": "3.0.2",
@@ -161,3 +161,16 @@ class TestPurePythonValidator:
         expectation = nullcontext() if valid else pytest.raises(jsonschema.ValidationError)
         with expectation:
             validator.validate_response(path='/with_ref', method='get', response=resp(body=body))
+
+
+def test_capabilities_has_endpoint():
+    capabilities = Capabilities({
+        'endpoints': [
+            {'path': '/collections', 'methods': ['GET']},
+        ]
+    })
+    assert capabilities.has_endpoint('/collections')
+    assert capabilities.has_endpoint('/collections', method='get')
+    assert capabilities.has_endpoint('/collections', method='GET')
+    assert not capabilities.has_endpoint('/collections', method='POST')
+    assert not capabilities.has_endpoint('/services', method='GET')


### PR DESCRIPTION
Addresses problem discussed in #28 :  a backend only has to support endpoints it claims to support