### PR TITLE
travis test matrix: helper tests must pass, "allow_failures" for actual backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,21 @@ python:
   - "3.6"
 matrix:
   include:
+  - name: "Validator tests"
+    env: PYTEST_ARGS="test_helpers.py"
   - name: "EARTHENGINE-0.4"
-    env: BACKEND=https://earthengine.openeo.org/v0.4 APIVERSION=0.4.2
+    env: PYTEST_ARGS="--backend https://earthengine.openeo.org/v0.4 --api-version 0.4.2"
   - name: "VITO-0.3.1"
-    env: BACKEND=http://openeo.vgt.vito.be/openeo/0.3.1 APIVERSION=0.3.1
+    env: PYTEST_ARGS="--backend http://openeo.vgt.vito.be/openeo/0.3.1"
   - name: "VITO-0.4.0"
-    env: BACKEND=http://openeo.vgt.vito.be/openeo/0.4.0 APIVERSION=0.4.0
+    env: PYTEST_ARGS="--backend http://openeo.vgt.vito.be/openeo/0.4.0"
   - name: "EURAC-0.3.1"
-    env: BACKEND=http://saocompute.eurac.edu/openEO_0_3_0/openeo APIVERSION=0.3.1
+    env: PYTEST_ARGS="--backend http://saocompute.eurac.edu/openEO_0_3_0/openeo --api-version 0.3.1"
+  allow_failures:
+  - env: PYTEST_ARGS="--backend https://earthengine.openeo.org/v0.4 --api-version 0.4.2"
+  - env: PYTEST_ARGS="--backend http://openeo.vgt.vito.be/openeo/0.3.1"
+  - env: PYTEST_ARGS="--backend http://openeo.vgt.vito.be/openeo/0.4.0"
+  - env: PYTEST_ARGS="--backend http://saocompute.eurac.edu/openEO_0_3_0/openeo --api-version 0.3.1"
 # command to install dependencies
 before_install:
   - cd openeo_compliance_tests
@@ -20,4 +27,4 @@ install:
 # command to run tests
 script:
   - cd openeo_compliance_tests
-  - pytest --backend $BACKEND --api-version $APIVERSION
+  - pytest $PYTEST_ARGS


### PR DESCRIPTION
alternative for PR #26 : test matrix with:
- test the helpers (no actual backend being used), all tests must pass
- run validation tests against actual backends, failures do not fail the build