### PR TITLE
Explicitly set Content-Length header of request

### DIFF
--- a/openeoct/openeoct.go
+++ b/openeoct/openeoct.go
@@ -295,6 +295,7 @@ func (ct *ComplianceTest) buildRequest(endpoint Endpoint, token string, abs_url 
 		stringReader := strings.NewReader(string(dat))
 		stringReadCloser := ioutil.NopCloser(stringReader)
 		httpReq.Body = stringReadCloser
+		httpReq.ContentLength = int64(len(string(dat)))
 
 	} else if os.IsNotExist(err) {
 		// path/to/whatever does *not* exist


### PR DESCRIPTION
For the D28 deliverable we have issues with missing POST data when running the validator against our HTTPS version of the VITO backend (https://openeo.vito.be). As workaround we run the validator against a HTTP version of the web app:  http://openeo.vgt.vito.be .

It turns out that it is because of the combination of:
- the go http library is using HTTP/2 mode when running against the HTTPS version of our backend
- there is no explicit `Content-length` header in the request.

For some still to determined reason the POST data is lost probably somewhere on the level of our HTTPS proxy setup.

This PR adds explicit setting of the `Content-length` header to workaround this issue